### PR TITLE
Update index.js

### DIFF
--- a/src/src/declarations/icp_rust_boilerplate_backend/index.js
+++ b/src/src/declarations/icp_rust_boilerplate_backend/index.js
@@ -4,16 +4,23 @@ import { Actor, HttpAgent } from "@dfinity/agent";
 import { idlFactory } from "./icp_rust_boilerplate_backend.did.js";
 export { idlFactory } from "./icp_rust_boilerplate_backend.did.js";
 
-/* CANISTER_ID is replaced by webpack based on node environment
+/* CANISTER_ID is replaced by webpack based on the node environment
  * Note: canister environment variable will be standardized as
  * process.env.CANISTER_ID_<CANISTER_NAME_UPPERCASE>
  * beginning in dfx 0.15.0
  */
 export const canisterId =
   process.env.CANISTER_ID_ICP_RUST_BOILERPLATE_BACKEND ||
-  process.env.ICP_RUST_BOILERPLATE_BACKEND_CANISTER_ID;
+  process.env.ICP_Rust_Boilerplate_Backend_Canister_ID;
+
+// Cached actor instance
+let cachedActor = null;
 
 export const createActor = (canisterId, options = {}) => {
+  if (cachedActor) {
+    return cachedActor; // Return the cached actor if it exists
+  }
+
   const agent = options.agent || new HttpAgent({ ...options.agentOptions });
 
   if (options.agent && options.agentOptions) {
@@ -24,20 +31,26 @@ export const createActor = (canisterId, options = {}) => {
 
   // Fetch root key for certificate validation during development
   if (process.env.DFX_NETWORK !== "ic") {
-    agent.fetchRootKey().catch((err) => {
-      console.warn(
-        "Unable to fetch root key. Check to ensure that your local replica is running"
-      );
-      console.error(err);
-    });
+    try {
+      await agent.fetchRootKey();
+    } catch (err) {
+      throw new Error("Unable to fetch root key. Make sure your local replica is running.");
+    }
   }
 
-  // Creates an actor with using the candid interface and the HttpAgent
-  return Actor.createActor(idlFactory, {
+  // Check if the canisterId is valid
+  if (!Actor.isValidCanisterId(canisterId)) {
+    throw new Error("Invalid canisterId. Please provide a valid canister ID.");
+  }
+
+  // Creates an actor with the candid interface and the HttpAgent
+  cachedActor = Actor.createActor(idlFactory, {
     agent,
     canisterId,
     ...options.actorOptions,
   });
+
+  return cachedActor;
 };
 
 export const icp_rust_boilerplate_backend = createActor(canisterId);


### PR DESCRIPTION
Errors:

The createActor function does not handle errors properly. If the agent.fetchRootKey() call fails, it only logs a warning and proceeds with the actor creation. This could lead to certificate validation errors later on. The createActor function does not check if the canisterId is a valid canister ID. This could lead to errors if the canister ID is not valid. Typos:

The ICP_RUST_BOILERPLATE_BACKEND_CANISTER_ID environment variable is not camel-cased correctly. It should be ICP_Rust_Boilerplate_Backend_Canister_ID. Bugs:

The createActor function does not cache the actor instance. This means that a new actor instance is created every time the function is called. This could be inefficient if the actor is used frequently. Here are some suggestions for fixing the errors and bugs:

Errors:

To handle the agent.fetchRootKey() error properly, you could throw an error or return an Err result from the createActor function. This would allow the caller to handle the error appropriately. To check if the canisterId is valid, you could use the Actor.isValidCanisterId() function. If the canisterId is not valid, you could throw an error or return an Err result from the createActor function. Typos:

You could rename the ICP_RUST_BOILERPLATE_BACKEND_CANISTER_ID environment variable to ICP_Rust_Boilerplate_Backend_Canister_ID. Bugs:

To cache the actor instance, you could create a global variable to store the actor instance. This would allow the createActor function to return the cached actor instance if it already exists.